### PR TITLE
fix(deny): use cargo-deny-action for cleaner output

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -26,5 +26,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
-      - uses: taiki-e/install-action@cargo-deny
-      - run: cargo deny ${{ inputs.deny-flags }} check all
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check all
+          arguments: ${{ inputs.deny-flags }}


### PR DESCRIPTION
Fixes #1

Replaces manual `cargo deny` invocation with [EmbarkStudios/cargo-deny-action](https://github.com/EmbarkStudios/cargo-deny-action). This action parses JSON output and creates GitHub annotations, keeping CI logs clean and making issues clickable in PRs.