### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto assign PR to author (with permission checks)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request

--- a/.github/workflows/cargo-update-pr.yml
+++ b/.github/workflows/cargo-update-pr.yml
@@ -39,7 +39,7 @@ jobs:
     name: Update
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
@@ -62,7 +62,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           add-paths: ./Cargo.lock
           commit-message: ${{ steps.msg.outputs.commit_message }}

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -22,7 +22,7 @@ jobs:
     name: cargo deny check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.rust-toolchain }}


### PR DESCRIPTION
Update all workflow action versions to latest:

- `actions/checkout` v4 → v6
- `peter-evans/create-pull-request` v7 → v8
- `actions/github-script` v7 → v8