### PR TITLE
feat: add release-signing reusable workflow

### DIFF
--- a/.github/workflows/release-signing.yml
+++ b/.github/workflows/release-signing.yml
@@ -1,0 +1,350 @@
+name: Release Signing & Attestation
+
+on:
+  workflow_call:
+    inputs:
+      # --- Artifact identification ---
+      artifact-pattern:
+        description: "Pattern to download build artifacts (passed to actions/download-artifact pattern)"
+        required: true
+        type: string
+      subject-path:
+        description: "Glob for files to sign/attest (e.g. 'artifacts/**/*.tar.gz')"
+        required: true
+        type: string
+
+      # --- Opt-out flags (all ON by default) ---
+      gpg-sign:
+        description: "GPG-sign archives"
+        default: true
+        type: boolean
+      attest-provenance:
+        description: "SLSA build provenance attestation"
+        default: true
+        type: boolean
+      generate-sbom:
+        description: "Generate SBOM and attest it"
+        default: true
+        type: boolean
+      macos-codesign:
+        description: "Apple codesign + notarize macOS binaries"
+        default: true
+        type: boolean
+
+      # --- macOS codesign options ---
+      macos-artifact-names:
+        description: "Space-separated artifact names containing unsigned macOS binaries"
+        required: false
+        default: ""
+        type: string
+      macos-binary-names:
+        description: "Space-separated binary filenames to sign inside each macOS artifact"
+        required: false
+        default: ""
+        type: string
+
+      # --- SBOM options ---
+      sbom-format:
+        description: "SBOM output format"
+        default: "spdx-json"
+        type: string
+
+    secrets:
+      GPG_SIGNING_KEY:
+        required: false
+      GPG_PASSPHRASE:
+        required: false
+      APPLE_CERTIFICATE_P12:
+        required: false
+      APPLE_CERTIFICATE_PASSWORD:
+        required: false
+      APPLE_TEAM_ID:
+        required: false
+      APPLE_NOTARY_KEY_ID:
+        required: false
+      APPLE_NOTARY_ISSUER:
+        required: false
+      APPLE_NOTARY_KEY_P8:
+        required: false
+
+jobs:
+  # ── Validate inputs ──
+  validate:
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check required secrets for enabled features
+        env:
+          GPG_ENABLED: ${{ inputs.gpg-sign }}
+          GPG_KEY_LEN: ${{ secrets.GPG_SIGNING_KEY && '1' || '0' }}
+          GPG_PASS_LEN: ${{ secrets.GPG_PASSPHRASE && '1' || '0' }}
+          MACOS_ENABLED: ${{ inputs.macos-codesign }}
+          MACOS_ARTIFACTS: ${{ inputs.macos-artifact-names }}
+          MACOS_BINARIES: ${{ inputs.macos-binary-names }}
+          APPLE_CERT_LEN: ${{ secrets.APPLE_CERTIFICATE_P12 && '1' || '0' }}
+          APPLE_PASS_LEN: ${{ secrets.APPLE_CERTIFICATE_PASSWORD && '1' || '0' }}
+          APPLE_TEAM_LEN: ${{ secrets.APPLE_TEAM_ID && '1' || '0' }}
+          APPLE_KEY_ID_LEN: ${{ secrets.APPLE_NOTARY_KEY_ID && '1' || '0' }}
+          APPLE_ISSUER_LEN: ${{ secrets.APPLE_NOTARY_ISSUER && '1' || '0' }}
+          APPLE_KEY_LEN: ${{ secrets.APPLE_NOTARY_KEY_P8 && '1' || '0' }}
+        run: |
+          FAILED=0
+
+          if [ "$GPG_ENABLED" = "true" ]; then
+            if [ "$GPG_KEY_LEN" = "0" ] || [ "$GPG_PASS_LEN" = "0" ]; then
+              echo "::error::gpg-sign is enabled but GPG_SIGNING_KEY or GPG_PASSPHRASE secret is missing"
+              FAILED=1
+            fi
+          fi
+
+          if [ "$MACOS_ENABLED" = "true" ] && [ -n "$MACOS_ARTIFACTS" ]; then
+            if [ -z "$MACOS_BINARIES" ]; then
+              echo "::error::macos-codesign is enabled with macos-artifact-names but macos-binary-names is empty"
+              FAILED=1
+            fi
+            for secret_name in APPLE_CERT APPLE_PASS APPLE_TEAM APPLE_KEY_ID APPLE_ISSUER APPLE_KEY; do
+              var="${secret_name}_LEN"
+              if [ "${!var}" = "0" ]; then
+                echo "::error::macos-codesign is enabled but $secret_name secret is missing"
+                FAILED=1
+              fi
+            done
+          fi
+
+          [ "$FAILED" = "0" ] || exit 1
+
+  # ── macOS code signing + notarization ──
+  macos-codesign:
+    name: macOS Codesign
+    needs: validate
+    if: ${{ inputs.macos-codesign && inputs.macos-artifact-names != '' }}
+    runs-on: macos-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Import Apple certificate
+        env:
+          CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          echo -n "$CERTIFICATE_P12" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" \
+            -P "$CERTIFICATE_PASSWORD" \
+            -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/xcrun \
+            -T /usr/bin/security
+          rm -f "$RUNNER_TEMP/certificate.p12"
+
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+          # Discover the signing identity from the imported cert
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | awk '/Developer ID Application/ {print $2; exit}')
+          if [ -z "$IDENTITY" ]; then
+            echo "::error::No Developer ID Application identity found in keychain"
+            exit 1
+          fi
+          echo "Found identity: $IDENTITY"
+
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "CODESIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+
+      - name: Sign and notarize binaries
+        env:
+          NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
+          NOTARY_KEY_P8: ${{ secrets.APPLE_NOTARY_KEY_P8 }}
+          ARTIFACT_NAMES: ${{ inputs.macos-artifact-names }}
+          BINARY_NAMES: ${{ inputs.macos-binary-names }}
+        run: |
+          NOTARY_KEY_PATH="$RUNNER_TEMP/notary-key.p8"
+          echo -n "$NOTARY_KEY_P8" | base64 --decode > "$NOTARY_KEY_PATH"
+          trap 'rm -f "$NOTARY_KEY_PATH"' EXIT
+
+          for artifact in $ARTIFACT_NAMES; do
+            ARTIFACT_DIR="artifacts/$artifact"
+            [ -d "$ARTIFACT_DIR" ] || { echo "::warning::Artifact dir not found: $ARTIFACT_DIR"; continue; }
+
+            for binary in $BINARY_NAMES; do
+              BINARY_PATH="$ARTIFACT_DIR/$binary"
+              [ -f "$BINARY_PATH" ] || continue
+
+              echo "==> Signing $BINARY_PATH"
+              codesign --force --options runtime \
+                --keychain "$KEYCHAIN_PATH" \
+                --sign "$CODESIGN_IDENTITY" \
+                --timestamp \
+                "$BINARY_PATH"
+
+              codesign --verify --verbose "$BINARY_PATH"
+
+              echo "==> Notarizing $binary from $artifact"
+              ZIP_PATH="$RUNNER_TEMP/${artifact}-${binary}.zip"
+              ditto -c -k --keepParent "$BINARY_PATH" "$ZIP_PATH"
+
+              xcrun notarytool submit "$ZIP_PATH" \
+                --key "$NOTARY_KEY_PATH" \
+                --key-id "$NOTARY_KEY_ID" \
+                --issuer "$NOTARY_ISSUER" \
+                --wait --timeout 600
+
+              rm -f "$ZIP_PATH"
+              echo "✓ $binary signed and notarized"
+            done
+          done
+
+      - name: Upload signed artifacts
+        uses: actions/upload-artifact@v4
+        env:
+          ARTIFACT_NAMES: ${{ inputs.macos-artifact-names }}
+        with:
+          name: macos-signed
+          path: artifacts/
+          overwrite: true
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+
+  # ── GPG signing ──
+  # Runs after macOS codesign so GPG signatures cover the final signed binaries.
+  gpg-sign:
+    name: GPG Sign
+    needs: [validate, macos-codesign]
+    # Run if validate succeeded and macos-codesign either succeeded or was skipped
+    if: >-
+      ${{
+        always() &&
+        inputs.gpg-sign &&
+        needs.validate.result == 'success' &&
+        contains(fromJSON('["success","skipped"]'), needs.macos-codesign.result)
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ inputs.artifact-pattern }}
+          path: artifacts
+          merge-multiple: true
+
+      - name: GPG sign archives
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          SUBJECT_PATH: ${{ inputs.subject-path }}
+        shell: bash
+        run: |
+          GNUPGHOME=$(mktemp -d)
+          export GNUPGHOME
+          trap 'rm -rf "$GNUPGHOME"' EXIT
+
+          echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import
+
+          shopt -s globstar nullglob
+          for file in $SUBJECT_PATH; do
+            [ -f "$file" ] || continue
+            echo "==> Signing $file"
+            printf '%s' "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab "$file"
+          done
+          shopt -u globstar nullglob
+
+      - name: Upload GPG signatures
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpg-signatures
+          path: artifacts/**/*.asc
+
+  # ── SBOM generation ──
+  sbom:
+    name: Generate SBOM
+    needs: validate
+    if: ${{ inputs.generate-sbom }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          format: ${{ inputs.sbom-format }}
+          output-file: sbom.json
+          upload-artifact: false
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.json
+
+  # ── Attestation (provenance + SBOM) ──
+  attest:
+    name: Attest
+    needs: [macos-codesign, gpg-sign, sbom]
+    if: >-
+      ${{
+        always() &&
+        (inputs.attest-provenance || inputs.generate-sbom) &&
+        contains(fromJSON('["success","skipped"]'), needs.macos-codesign.result) &&
+        contains(fromJSON('["success","skipped"]'), needs.gpg-sign.result) &&
+        contains(fromJSON('["success","skipped"]'), needs.sbom.result)
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+      actions: read
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ inputs.artifact-pattern }}
+          path: artifacts
+          merge-multiple: true
+
+      - name: Build provenance attestation
+        if: ${{ inputs.attest-provenance }}
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ inputs.subject-path }}
+
+      - name: Download SBOM
+        if: ${{ inputs.generate-sbom }}
+        uses: actions/download-artifact@v4
+        with:
+          name: sbom
+          path: sbom
+
+      - name: SBOM attestation
+        if: ${{ inputs.generate-sbom }}
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ inputs.subject-path }}
+          sbom-path: sbom/sbom.json


### PR DESCRIPTION
Single reusable `workflow_call` for release artifact signing and attestation. All features enabled by default, opt-out via boolean inputs.

**Capabilities:**
- macOS code signing + notarization (Developer ID, `notarytool`)
- GPG archive signing
- SLSA build provenance attestation (`actions/attest@v4`)
- SBOM generation (`anchore/sbom-action`) + SBOM attestation
