### PR TITLE
fix(ci): harden reusable workflows

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto assign PR to author (with permission checks)
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const pr = context.payload.pull_request

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto assign PR to author (with permission checks)
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request

--- a/.github/workflows/cargo-update-pr.yml
+++ b/.github/workflows/cargo-update-pr.yml
@@ -18,6 +18,8 @@ on:
         description: "GITHUB_TOKEN. See https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#token"
         required: true
 
+permissions: {}
+
 env:
   GITHUB_TOKEN: ${{ secrets.token }}
   BRANCH: cargo-update
@@ -39,7 +41,9 @@ jobs:
     name: Update
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
@@ -50,11 +54,13 @@ jobs:
 
       - name: Craft commit message and PR body
         id: msg
+        env:
+          PR_TITLE: ${{ inputs.title }}
         run: |
           export cargo_update_log="$(cat cargo_update.log)"
 
           echo "commit_message<<EOF" >> $GITHUB_OUTPUT
-          printf "%s\n\n%s\n" '${{ inputs.title }}' "$cargo_update_log" >> $GITHUB_OUTPUT
+          printf "%s\n\n%s\n" "$PR_TITLE" "$cargo_update_log" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
           echo "body<<EOF" >> $GITHUB_OUTPUT
@@ -62,7 +68,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           add-paths: ./Cargo.lock
           commit-message: ${{ steps.msg.outputs.commit_message }}

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -14,6 +14,8 @@ on:
         required: false
         type: "string"
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -22,11 +24,13 @@ jobs:
     name: cargo deny check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.rust-toolchain }}
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@175dc7fd4fb85ec8f46948fb98f44db001149081 # v2.0.16
         with:
           command: check all
           arguments: ${{ inputs.deny-flags }}


### PR DESCRIPTION
Fixes all actionable findings from supply chain scan:

- **Pin actions to SHAs** — `actions/github-script`, `actions/checkout`, `peter-evans/create-pull-request`, `EmbarkStudios/cargo-deny-action` (`dtolnay/rust-toolchain@master` left as-is — intentionally rolling)
- **Fix template injection** — `${{ inputs.title }}` in `cargo-update-pr.yml` moved from inline shell interpolation to env var
- **Add `persist-credentials: false`** to `actions/checkout` in `cargo-update-pr.yml` and `deny.yml`
- **Add `permissions: {}`** top-level to `cargo-update-pr.yml` and `deny.yml` for least-privilege defaults

Prompted by: georgen