### PR TITLE
chore: add dependabot for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 1
+    groups:
+      github-actions-weekly:
+        applies-to: "version-updates"
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Adds a `dependabot.yml` to keep GitHub Actions versions up to date automatically.

- Weekly schedule with 7-day cooldown
- Groups minor + patch updates into a single PR
- Limits to 1 open PR at a time
- Conventional commit prefix `chore(deps)`

Inspired by [foundry-toolchain's config](https://github.com/foundry-rs/foundry-toolchain/blob/main/.github/dependabot.yml). Follow-up to [PR #5](https://github.com/tempoxyz/ci/pull/5).

Prompted by: zerosnacks