### PR TITLE
fix(ci): allow deny workflow checkout

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -14,7 +14,8 @@ on:
         required: false
         type: "string"
 
-permissions: {}
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The reusable deny workflow currently sets an empty permissions map, which prevents actions/checkout from reading caller repositories in protected or restricted token contexts. Grant contents: read so checkout can complete before cargo-deny runs.